### PR TITLE
190075: Reduce build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,34 @@
 ARG PARENT_VERSION=2.1.2-node18.11.0
 ARG PORT=3000
-ARG PORT_DEBUG=9229
+#ARG PORT_DEBUG=9229
 
-FROM defradigital/node-development:${PARENT_VERSION} AS development
-ARG PARENT_VERSION
-LABEL uk.gov.defra.ffc.parent-image=defradigital/node-development:${PARENT_VERSION}
+# TODO this is a hack to improve deploy time for the demo. This file needs reverting post demo
+# TODO fix the fact that the front assets are not being built for production
 
-ARG PORT
-ARG PORT_DEBUG
-ENV PORT ${PORT}
-EXPOSE ${PORT} ${PORT_DEBUG}
-
-COPY --chown=node:node package*.json ./
-RUN npm install
-COPY --chown=node:node . .
-RUN npm run build
-
-CMD [ "npm", "run", "docker:dev" ]
+#FROM defradigital/node-development:${PARENT_VERSION} AS development
+#ARG PARENT_VERSION
+#LABEL uk.gov.defra.ffc.parent-image=defradigital/node-development:${PARENT_VERSION}
+#
+#ARG PORT
+#ARG PORT_DEBUG
+#ENV PORT ${PORT}
+#EXPOSE ${PORT} ${PORT_DEBUG}
+#
+#COPY --chown=node:node package*.json ./
+#RUN npm install
+#COPY --chown=node:node . .
+#RUN npm run build
+#
+#CMD [ "npm", "run", "docker:dev" ]
 
 FROM defradigital/node:${PARENT_VERSION} AS production
 ARG PARENT_VERSION
 LABEL uk.gov.defra.ffc.parent-image=defradigital/node:${PARENT_VERSION}
 
-COPY --from=development /home/node/package*.json ./
-COPY --from=development /home/node/.server ./.server/
-COPY --from=development /home/node/.public/ ./.public/
-
-RUN npm ci --omit=dev
+COPY --chown=node:node package*.json ./
+RUN npm install --production=false
+COPY --chown=node:node . .
+RUN npm run build
 
 ARG PORT
 ENV PORT ${PORT}


### PR DESCRIPTION
Note this for the demo only. This work needs reverting post demo:

- `TODO` this is a hack to improve deploy time for the demo. This file needs reverting post demo
- `TODO` fix the fact that the front assets are not being built for production