### PR TITLE
Asset path fix if not public or no app prefix

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -35,7 +35,7 @@ const config = convict({
   assetPath: {
     doc: 'Asset path',
     format: String,
-    default: 'public',
+    default: '/public',
     env: 'ASSET_PATH'
   },
   appPathPrefix: {

--- a/src/config/nunjucks/context/index.js
+++ b/src/config/nunjucks/context/index.js
@@ -29,7 +29,7 @@ function context(request) {
     getAssetPath: function (asset) {
       const webpackAssetPath = webpackManifest[asset]
 
-      return `${appPathPrefix}/${assetPath}/${webpackAssetPath}`
+      return `${appPathPrefix}${assetPath}/${webpackAssetPath}`
     }
   }
 }

--- a/src/server/common/helpers/serve-static-files.js
+++ b/src/server/common/helpers/serve-static-files.js
@@ -28,7 +28,7 @@ const serveStaticFiles = {
             }
           },
           method: 'GET',
-          path: '/public/{param*}',
+          path: `${config.get('assetPath')}/{param*}`,
           handler: {
             directory: {
               path: '.',


### PR DESCRIPTION
Pulling changes from the example app for the asset fixes only.

This should prevent problems if assets path changes irrespective of whether there is an app path prefix.