### PR TITLE
App Prefix or not

### DIFF
--- a/src/config/nunjucks/context/index.js
+++ b/src/config/nunjucks/context/index.js
@@ -29,7 +29,11 @@ function context(request) {
     getAssetPath: function (asset) {
       const webpackAssetPath = webpackManifest[asset]
 
-      return `${appPathPrefix}${assetPath}/${webpackAssetPath}`
+      if (!appPathPrefix || appPathPrefix === '/') {
+        return `${assetPath}/${webpackAssetPath}`
+      } else {
+        return `${appPathPrefix}${assetPath}/${webpackAssetPath}`
+      }
     }
   }
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -9,6 +9,7 @@ import { catchAll } from '~/src/server/common/helpers/errors'
 import { secureContext } from '~/src/server/common/helpers/secure-context'
 
 const isProduction = config.get('isProduction')
+const appPathPrefix = config.get('appPathPrefix')
 
 async function createServer() {
   const server = hapi.server({
@@ -44,9 +45,13 @@ async function createServer() {
     await server.register(secureContext)
   }
 
-  await server.register(router, {
-    routes: { prefix: config.get('appPathPrefix') }
-  })
+  if (!appPathPrefix || appPathPrefix === '/') {
+    await server.register(router)
+  } else {
+    await server.register(router, {
+      routes: { prefix: appPathPrefix }
+    })
+  }
 
   await server.register(nunjucksConfig)
 


### PR DESCRIPTION
Following on from the example app this checks if the app prefix path has been set and handles if is blank or a / and effectively removes it. E.g. in a vanity URL deployment.