### PR TITLE
Update `stylelint` to fix peer dependency issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "sass": "1.74.1",
         "sass-loader": "14.1.1",
         "source-map-loader": "5.0.0",
-        "stylelint": "16.3.1",
+        "stylelint": "16.7.0",
         "stylelint-config-gds": "2.0.0",
         "terser-webpack-plugin": "5.3.10",
         "tsx": "4.16.2",
@@ -10661,10 +10661,11 @@
       }
     },
     "node_modules/known-css-properties": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.30.0.tgz",
-      "integrity": "sha512-VSWXYUnsPu9+WYKkfmJyLKtIvaRJi1kXUqVmBACORXZQxT5oZDsoZ2vQP+bQFDnWtpI/4eq3MLoRMjI2fnLzTQ==",
-      "dev": true
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.34.0.tgz",
+      "integrity": "sha512-tBECoUqNFbyAY4RrbqsBQqDFpGXAEbdD5QKr8kACx3+rnArmuuR22nKQWKazvp07N9yjTyDZaw/20UIH8tL9DQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -13344,25 +13345,36 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.3.1.tgz",
-      "integrity": "sha512-/JOwQnBvxEKOT2RtNgGpBVXnCSMBgKOL2k7w0K52htwCyJls4+cHvc4YZgXlVoAZS9QJd2DgYAiRnja96pTgxw==",
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.7.0.tgz",
+      "integrity": "sha512-Q1ATiXlz+wYr37a7TGsfvqYn2nSR3T/isw3IWlZQzFzCNoACHuGBb6xBplZXz56/uDRJHIygxjh7jbV/8isewA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "@csstools/css-parser-algorithms": "^2.6.1",
-        "@csstools/css-tokenizer": "^2.2.4",
-        "@csstools/media-query-list-parser": "^2.1.9",
-        "@csstools/selector-specificity": "^3.0.2",
-        "@dual-bundle/import-meta-resolve": "^4.0.0",
+        "@csstools/css-parser-algorithms": "^2.7.1",
+        "@csstools/css-tokenizer": "^2.4.1",
+        "@csstools/media-query-list-parser": "^2.1.13",
+        "@csstools/selector-specificity": "^3.1.1",
+        "@dual-bundle/import-meta-resolve": "^4.1.0",
         "balanced-match": "^2.0.0",
         "colord": "^2.9.3",
         "cosmiconfig": "^9.0.0",
-        "css-functions-list": "^3.2.1",
+        "css-functions-list": "^3.2.2",
         "css-tree": "^2.3.1",
-        "debug": "^4.3.4",
+        "debug": "^4.3.5",
         "fast-glob": "^3.3.2",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^8.0.0",
+        "file-entry-cache": "^9.0.0",
         "global-modules": "^2.0.0",
         "globby": "^11.1.0",
         "globjoin": "^0.1.4",
@@ -13370,23 +13382,23 @@
         "ignore": "^5.3.1",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.30.0",
+        "known-css-properties": "^0.34.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^13.2.0",
-        "micromatch": "^4.0.5",
+        "micromatch": "^4.0.7",
         "normalize-path": "^3.0.0",
-        "picocolors": "^1.0.0",
-        "postcss": "^8.4.38",
+        "picocolors": "^1.0.1",
+        "postcss": "^8.4.39",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-safe-parser": "^7.0.0",
-        "postcss-selector-parser": "^6.0.16",
+        "postcss-selector-parser": "^6.1.0",
         "postcss-value-parser": "^4.2.0",
         "resolve-from": "^5.0.0",
         "string-width": "^4.2.3",
         "strip-ansi": "^7.1.0",
         "supports-hyperlinks": "^3.0.0",
         "svg-tags": "^1.0.0",
-        "table": "^6.8.1",
+        "table": "^6.8.2",
         "write-file-atomic": "^5.0.1"
       },
       "bin": {
@@ -13394,10 +13406,6 @@
       },
       "engines": {
         "node": ">=18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/stylelint"
       }
     },
     "node_modules/stylelint-config-gds": {
@@ -13524,12 +13532,6 @@
         "stylelint": "^16.0.2"
       }
     },
-    "node_modules/stylelint-scss/node_modules/known-css-properties": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.34.0.tgz",
-      "integrity": "sha512-tBECoUqNFbyAY4RrbqsBQqDFpGXAEbdD5QKr8kACx3+rnArmuuR22nKQWKazvp07N9yjTyDZaw/20UIH8tL9DQ==",
-      "dev": true
-    },
     "node_modules/stylelint/node_modules/ansi-regex": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
@@ -13549,28 +13551,30 @@
       "dev": true
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-9.0.0.tgz",
+      "integrity": "sha512-6MgEugi8p2tiUhqO7GnPsmbCCzj0YRCwwaTbpGRyKZesjRSzkqkAE9fPp7V2yMs5hwfgbQLgdvSSkGNg1s5Uvw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "flat-cache": "^4.0.0"
+        "flat-cache": "^5.0.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/stylelint/node_modules/flat-cache": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
+      "integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "flatted": "^3.2.9",
+        "flatted": "^3.3.1",
         "keyv": "^4.5.4"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/stylelint/node_modules/globby": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "sass": "1.74.1",
     "sass-loader": "14.1.1",
     "source-map-loader": "5.0.0",
-    "stylelint": "16.3.1",
+    "stylelint": "16.7.0",
     "stylelint-config-gds": "2.0.0",
     "terser-webpack-plugin": "5.3.10",
     "tsx": "4.16.2",


### PR DESCRIPTION
The recent [package updates](https://github.com/DEFRA/cdp-node-frontend-template/pull/85/commits/0f4e5561f14588fc521de843f0e8e9e13c2823bc) require a (slightly) higher minimum `stylelint` version for `stylelint-config-gds`

This PR bumps [`stylelint@16.3.1`](https://github.com/stylelint/stylelint/releases/tag/16.3.1) to [`stylelint@16.7.0`](https://github.com/stylelint/stylelint/releases/tag/16.7.0) to resolve the npm install warnings:

```console
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: stylelint-config-recommended-scss@14.1.0
npm warn Found: stylelint@16.3.1
npm warn node_modules/stylelint
npm warn   dev stylelint@"16.3.1" from the root project
npm warn   5 more (stylelint-config-gds, stylelint-config-recommended, ...)
npm warn
npm warn Could not resolve dependency:
npm warn peer stylelint@"^16.6.1" from stylelint-config-recommended-scss@14.1.0
npm warn node_modules/stylelint-config-standard-scss/node_modules/stylelint-config-recommended-scss
npm warn   stylelint-config-recommended-scss@"^14.0.0" from stylelint-config-standard-scss@13.1.0
npm warn   node_modules/stylelint-config-standard-scss
npm warn
npm warn Conflicting peer dependency: stylelint@16.7.0
npm warn node_modules/stylelint
npm warn   peer stylelint@"^16.6.1" from stylelint-config-recommended-scss@14.1.0
npm warn   node_modules/stylelint-config-standard-scss/node_modules/stylelint-config-recommended-scss
npm warn     stylelint-config-recommended-scss@"^14.0.0" from stylelint-config-standard-scss@13.1.0
npm warn     node_modules/stylelint-config-standard-scss
```