### PR TITLE
Tweaks to the templates

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,7 +19,7 @@ module.exports = {
       env: {
         browser: false
       },
-      files: ['**/*.{cjs,js}'],
+      files: ['**/*.{cjs,js,ts}'],
       parser: '@typescript-eslint/parser',
       parserOptions: {
         ecmaVersion: 'latest',

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ export default {
   verbose: true,
   resetModules: true,
   clearMocks: true,
-  silent: true,
+  silent: false,
   testMatch: ['**/src/**/*.test.js'],
   reporters: ['default', ['github-actions', { silent: false }], 'summary'],
   collectCoverageFrom: ['src/**/*.js'],

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -102,6 +102,12 @@ export const config = convict({
     default: isProduction,
     env: 'ENABLE_SECURE_CONTEXT'
   },
+  enablePulse: {
+    doc: 'Enable Pulse',
+    format: Boolean,
+    default: isProduction,
+    env: 'ENABLE_PULSE'
+  },
   enableMetrics: {
     doc: 'Enable metrics reporting',
     format: Boolean,

--- a/src/server/common/helpers/secure-context/secure-context.js
+++ b/src/server/common/helpers/secure-context/secure-context.js
@@ -1,7 +1,9 @@
 import tls from 'node:tls'
+
 import { config } from '~/src/config/index.js'
 import { getTrustStoreCerts } from '~/src/server/common/helpers/secure-context/get-trust-store-certs.js'
 
+const enableSecureContext = config.get('enableSecureContext')
 /**
  * Creates a new secure context loaded from Base64 encoded certs
  * @satisfies {ServerRegisterPluginObject<void>}
@@ -10,7 +12,7 @@ export const secureContext = {
   plugin: {
     name: 'secure-context',
     register(server) {
-      if (config.get('enableSecureContext')) {
+      if (enableSecureContext) {
         const originalCreateSecureContext = tls.createSecureContext
 
         tls.createSecureContext = function (options = {}) {
@@ -28,12 +30,9 @@ export const secureContext = {
 
           return secureContext
         }
-
-        // @ts-expect-error TS2769
-        server.decorate('server', 'secureContext', tls.createSecureContext())
-      } else {
-        server.logger.info('Custom secure context is disabled')
       }
+
+      server.decorate('server', 'getSecureContext', tls.createSecureContext)
     }
   }
 }

--- a/src/server/common/helpers/secure-context/secure-context.js
+++ b/src/server/common/helpers/secure-context/secure-context.js
@@ -28,6 +28,8 @@ export const secureContext = {
             secureContext.context.addCACert(cert)
           })
 
+          server.logger.info('Custom secure context enabled')
+
           return secureContext
         }
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "types": ["jest"]
   },
   "exclude": [".cache", ".public", ".server", "coverage", "node_modules"],
-  "include": ["**/*.cjs", "**/*.js", ".eslintrc.*", ".prettierrc.*"]
+  "include": ["**/*.cjs", "**/*.js", ".*.cjs", ".*.js", "types/**/*.ts"]
 }

--- a/types/cdp-node-frontend-template.d.ts
+++ b/types/cdp-node-frontend-template.d.ts
@@ -1,0 +1,10 @@
+import { SecureContextOptions, SecureContext } from 'tls'
+
+declare module '@hapi/hapi' {
+  // Add additions to the Hapi Request interface here
+  // interface Request {}
+
+  interface Server {
+    getSecureContext: (options?: SecureContextOptions) => SecureContext
+  }
+}


### PR DESCRIPTION
- Turn on logging in tests
- Wrap pulse in a flag so its only enabled in `production`
- Add custom type declaration so decorators are available on `Server` and `Request`
- Rework secureContext so the decorator is always available
- Mirror hapi plugin comments from the backend template