### PR TITLE
Add jest ESM transform ignore work

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,7 +22,15 @@ export default {
     'index.js'
   ],
   coverageDirectory: '<rootDir>/coverage',
-  transformIgnorePatterns: ['/node_modules(?!/(@defra/hapi-tracing))'] // ESM only modules
+  transform: {
+    '^.+\\.js$': 'babel-jest'
+  },
+  transformIgnorePatterns: [
+    `node_modules/(?!${[
+      '@defra/hapi-tracing', // Supports ESM only
+      'node-fetch' // Supports ESM only
+    ].join('|')}/)`
+  ]
 }
 
 /**


### PR DESCRIPTION
If a dependency is ESM only then we need to instruct jest not to transform it. This work does that and also provides a simple way for teams to extend and add their own ESM only dependencies