### PR TITLE
Core 681 update gov frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "cssnano-preset-default": "^7.0.7",
         "date-fns": "^4.1.0",
         "global-agent": "^3.0.0",
-        "govuk-frontend": "^5.10.2",
+        "govuk-frontend": "^5.11.0",
         "hapi-pino": "^12.1.0",
         "hapi-pulse": "^3.0.1",
         "ioredis": "^5.6.1",
@@ -7533,9 +7533,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.10.2",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.10.2.tgz",
-      "integrity": "sha512-eVYB2rfUCihehZFHQyylt12/OuXq2JLs+70igcrB1FmbepcDqs1XwKiq96hsPbPF9Vn2f6QXO1OatyD3bq5c9Q==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.0.tgz",
+      "integrity": "sha512-RYZDEF1J6nVw5XauQGH+91qplExgHUXfXII7dtIme6I4u3eSvU59yZ0/EFKEwRgTslSqlhJODOnAi5rnQFU5Gw==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "lint:js": "eslint .",
     "lint:js:fix": "eslint . --fix",
     "lint:scss": "stylelint \"src/**/*.scss\" --cache --cache-location .cache/stylelint --cache-strategy content --color --ignore-path .gitignore",
-    "postversion": "git add package.json package-lock.json && git commit -m $npm_package_version",
     "pretest": "npm run build:frontend",
     "test": "TZ=UTC vitest run --coverage",
     "test:watch": "TZ=UTC vitest",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "cssnano-preset-default": "^7.0.7",
     "date-fns": "^4.1.0",
     "global-agent": "^3.0.0",
-    "govuk-frontend": "^5.10.2",
+    "govuk-frontend": "^5.11.0",
     "hapi-pino": "^12.1.0",
     "hapi-pulse": "^3.0.1",
     "ioredis": "^5.6.1",

--- a/src/config/nunjucks/globals/globals.js
+++ b/src/config/nunjucks/globals/globals.js
@@ -1,5 +1,3 @@
-// Turn on to enable GOV.UK rebrand - https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md#use-the-refreshed-govuk-brand-if-youre-using-our-nunjucks-page-template
-// TODO turn on once GOV.UK rebrand is complete, eta 25th June 2025
-const govukRebrand = false
+const govukRebrand = true
 
 export { govukRebrand }


### PR DESCRIPTION
- Bump `govuk-frontend` dependency
- Turn on rebrand by default


## Screenshot

<img width="1360" alt="Screenshot 2025-07-08 at 16 29 34" src="https://github.com/user-attachments/assets/3b3ec64b-9e7a-4aa4-81c9-8747ae7c28b8" />
